### PR TITLE
Add the paranormal scanner to Inquisitor ERT

### DIFF
--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -20,12 +20,12 @@
 	var/slip_tiles
 	/// TRUE If this slip can be avoided by walking.
 	var/walking_is_safe
-	/// TRUE if having no slip shoes makes you immune to this slip.
-	var/noslip_is_immune
+	/// FALSE if you want no slip shoes to make you immune to the slip
+	var/slip_always
 	/// The verb that players will see when someone slips on the parent. In the form of "You [slip_verb]ped on".
 	var/slip_verb
 
-/datum/component/slippery/Initialize(_description, _stun = 0, _weaken = 0, _slip_chance = 100, _slip_tiles = 0, _walking_is_safe = TRUE, _noslip_is_immune = TRUE, _slip_verb = "slip")
+/datum/component/slippery/Initialize(_description, _stun = 0, _weaken = 0, _slip_chance = 100, _slip_tiles = 0, _walking_is_safe = TRUE, _slip_always = FALSE, _slip_verb = "slip")
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -35,7 +35,7 @@
 	slip_chance = max(0, _slip_chance)
 	slip_tiles = max(0, _slip_tiles)
 	walking_is_safe = _walking_is_safe
-	noslip_is_immune = _noslip_is_immune
+	slip_always = _slip_always
 	slip_verb = _slip_verb
 
 /datum/component/slippery/RegisterWithParent()
@@ -51,6 +51,6 @@
 	Additionally calls the parent's `after_slip()` proc on the `victim`.
 */
 /datum/component/slippery/proc/Slip(datum/source, mob/living/carbon/human/victim)
-	if(istype(victim) && prob(slip_chance) && victim.slip(description, stun, weaken, slip_tiles, walking_is_safe, noslip_is_immune, slip_verb))
+	if(istype(victim) && prob(slip_chance) && victim.slip(description, stun, weaken, slip_tiles, walking_is_safe, slip_always, slip_verb))
 		var/atom/movable/owner = parent
 		owner.after_slip(victim)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -278,6 +278,7 @@
 	return 1
 
 /atom/movable/proc/onTransitZ(old_z,new_z)
+	SEND_SIGNAL(src, COMSIG_MOVABLE_Z_CHANGED, old_z, new_z)
 	for(var/item in src) // Notify contents of Z-transition. This can be overridden if we know the items contents do not care.
 		var/atom/movable/AM = item
 		AM.onTransitZ(old_z,new_z)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -278,7 +278,6 @@
 	return 1
 
 /atom/movable/proc/onTransitZ(old_z,new_z)
-	SEND_SIGNAL(src, COMSIG_MOVABLE_Z_CHANGED, old_z, new_z)
 	for(var/item in src) // Notify contents of Z-transition. This can be overridden if we know the items contents do not care.
 		var/atom/movable/AM = item
 		AM.onTransitZ(old_z,new_z)

--- a/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
+++ b/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
@@ -76,11 +76,11 @@
 		var/mob/living/carbon/human/H = owner
 		H.weakeyes = 1
 		if(!H.vision_type)
-			H.vision_type = new /datum/vision_override/nightvision
+			H.set_sight(new /datum/vision_override/nightvision)
 
 /obj/item/organ/internal/cyberimp/eyes/thermals/ling/remove(mob/living/carbon/M, special = 0)
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.weakeyes = 0
-		H.vision_type = null
+		H.set_sight(null)
 	..()

--- a/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
+++ b/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
@@ -76,7 +76,7 @@
 		var/mob/living/carbon/human/H = owner
 		H.weakeyes = 1
 		if(!H.vision_type)
-			H.set_sight(new /datum/vision_override/nightvision)
+			H.set_sight(/datum/vision_override/nightvision)
 
 /obj/item/organ/internal/cyberimp/eyes/thermals/ling/remove(mob/living/carbon/M, special = 0)
 	if(ishuman(owner))

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -184,7 +184,7 @@
 		var/mob/living/carbon/human/H = target
 		if(!H.vision_type)
 			to_chat(H, "<span class='notice'>You shift the nerves in your eyes, allowing you to see in the dark.</span>")
-			H.set_sight(new /datum/vision_override/nightvision)
+			H.set_sight(/datum/vision_override/nightvision)
 		else
 			to_chat(H, "<span class='notice'>You return your vision to normal.</span>")
 			H.set_sight(null)

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -187,7 +187,7 @@
 			H.set_sight(new /datum/vision_override/nightvision)
 		else
 			to_chat(H, "<span class='notice'>You return your vision to normal.</span>")
-			H.set_sight()
+			H.set_sight(null)
 
 /obj/effect/proc_holder/spell/targeted/shadow_vision/thrall
 	desc = "Thrall Darksight"

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -186,9 +186,12 @@
 		if(!H.vision_type)
 			to_chat(H, "<span class='notice'>You shift the nerves in your eyes, allowing you to see in the dark.</span>")
 			H.vision_type = new vision_path
+			H.update_sight()
+
 		else
 			to_chat(H, "<span class='notice'>You return your vision to normal.</span>")
 			H.vision_type = null
+			H.update_sight()
 
 /obj/effect/proc_holder/spell/targeted/shadow_vision/thrall
 	desc = "Thrall Darksight"

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -187,7 +187,6 @@
 			to_chat(H, "<span class='notice'>You shift the nerves in your eyes, allowing you to see in the dark.</span>")
 			H.vision_type = new vision_path
 			H.update_sight()
-
 		else
 			to_chat(H, "<span class='notice'>You return your vision to normal.</span>")
 			H.vision_type = null

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -175,7 +175,6 @@
 	range = -1
 	include_user = 1
 	clothes_req = 0
-	var/datum/vision_override/vision_path = /datum/vision_override/nightvision
 	action_icon_state = "darksight"
 
 /obj/effect/proc_holder/spell/targeted/shadow_vision/cast(list/targets, mob/user = usr)
@@ -185,12 +184,10 @@
 		var/mob/living/carbon/human/H = target
 		if(!H.vision_type)
 			to_chat(H, "<span class='notice'>You shift the nerves in your eyes, allowing you to see in the dark.</span>")
-			H.vision_type = new vision_path
-			H.update_sight()
+			H.set_sight(new /datum/vision_override/nightvision)
 		else
 			to_chat(H, "<span class='notice'>You return your vision to normal.</span>")
-			H.vision_type = null
-			H.update_sight()
+			H.set_sight()
 
 /obj/effect/proc_holder/spell/targeted/shadow_vision/thrall
 	desc = "Thrall Darksight"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -856,3 +856,38 @@ proc/healthscan(mob/user, mob/living/M, mode = 1, upgraded = FALSE)
 		dat += "<font color='red'>Retinal misalignment detected.</font><BR>"
 
 	return dat
+
+/obj/item/paranormal_scanner
+	name = "paranormal scanner"
+	desc = "A device able to deep-scan a person to identify anomalous elements. Able to spot vampires and their thralls, Nar'Sie cultists, and wizards. Must be used next to the target, and takes a while to scan."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "spectrometer"
+	w_class = WEIGHT_CLASS_SMALL
+	slot_flags = SLOT_BELT
+	var/scan_time = 20 SECONDS
+
+/obj/item/paranormal_scanner/advanced
+	name = "advanced paranormal scanner"
+	icon = 'icons/obj/device.dmi'
+	icon_state = "adv_spectrometer"
+	scan_time = 10 SECONDS
+
+/obj/item/paranormal_scanner/attack(mob/living/M, mob/living/user)
+	if(user.incapacitated() || !user.Adjacent(M))
+		return
+	if(M && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		user.visible_message("[user] begins scanning [M] with [src].", "You begin scanning [M].")
+		if(do_after(user, scan_time, target = M))
+			if(H.mind && H.mind.vampire)
+				to_chat(user, "<span class='notice'>Scan result : </span><span class='danger'>VAMPIRE</span>")
+			else if(isvampirethrall(H))
+				to_chat(user, "<span class='notice'>Scan result : </span><span class='warning'>VAMPIRE THRALL</span>")
+			else if(iscultist(H))
+				to_chat(user, "<span class='notice'>Scan result : </span><span class='danger'>NAR'SIE CULTIST</span>")
+			else if(iswizard(H) || (H.mind && H.mind.special_role == SPECIAL_ROLE_WIZARD_APPRENTICE))
+				to_chat(user, "<span class='notice'>Scan result : </span><span class='userdanger'>WIZARD</span>")
+			else
+				to_chat(user, "<span class='notice'>Scan result : Ordinary</span>")
+	else
+		to_chat(user, "<span class='notice'>Error : Cannot scan [M].</span>")

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -862,7 +862,7 @@ proc/healthscan(mob/user, mob/living/M, mode = 1, upgraded = FALSE)
 
 /obj/item/paranormal_scanner
 	name = "paranormal scanner"
-	desc = "A device able to deep-scan a person to identify anomalous elements. Able to spot vampires and their thralls, Nar'Sie cultists, and wizards. Must be used next to the target, and takes a while to scan."
+	desc = "A device used to deep-scan a person to identify anomalous elements. Spots vampires and their thralls, Nar'Sie cultists, and wizards. Must be used next to the target, and takes a while to scan."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "spectrometer"
 	item_state = "analyzer"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -6,7 +6,10 @@ HEALTH ANALYZER
 GAS ANALYZER
 PLANT ANALYZER
 REAGENT SCANNER
+BODY ANALYZER
+PARANORMAL SCANNER
 */
+
 /obj/item/t_scanner
 	name = "T-ray scanner"
 	desc = "A terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."
@@ -862,13 +865,13 @@ proc/healthscan(mob/user, mob/living/M, mode = 1, upgraded = FALSE)
 	desc = "A device able to deep-scan a person to identify anomalous elements. Able to spot vampires and their thralls, Nar'Sie cultists, and wizards. Must be used next to the target, and takes a while to scan."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "spectrometer"
+	item_state = "analyzer"
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = SLOT_BELT
 	var/scan_time = 20 SECONDS
 
 /obj/item/paranormal_scanner/advanced
 	name = "advanced paranormal scanner"
-	icon = 'icons/obj/device.dmi'
 	icon_state = "adv_spectrometer"
 	scan_time = 10 SECONDS
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -862,7 +862,7 @@ proc/healthscan(mob/user, mob/living/M, mode = 1, upgraded = FALSE)
 
 /obj/item/paranormal_scanner
 	name = "paranormal scanner"
-	desc = "A device used to deep-scan a person to identify anomalous elements. Spots vampires and their thralls, Nar'Sie cultists, and wizards. Must be used next to the target, and takes a while to scan."
+	desc = "A device used to deep-scan a person to identify anomalous elements. Spots vampires and their thralls, Nar'Sie cultists, wizards and devils. Must be used next to the target, and takes a while to scan."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "spectrometer"
 	item_state = "analyzer"
@@ -890,6 +890,8 @@ proc/healthscan(mob/user, mob/living/M, mode = 1, upgraded = FALSE)
 				to_chat(user, "<span class='notice'>Scan result : </span><span class='danger'>NAR'SIE CULTIST</span>")
 			else if(iswizard(H) || (H.mind && H.mind.special_role == SPECIAL_ROLE_WIZARD_APPRENTICE))
 				to_chat(user, "<span class='notice'>Scan result : </span><span class='userdanger'>WIZARD</span>")
+			else if(H.mind && H.mind.devilinfo)
+				to_chat(user, "<span class='notice'>Scan result : </span><span class='userdanger'>DEVIL</span>")
 			else
 				to_chat(user, "<span class='notice'>Scan result : Ordinary</span>")
 	else

--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -191,25 +191,27 @@
 	origin_tech = null
 	selfcharge = 1
 	can_charge = 0
-	var/inawaymission = 1
+	var/inawaymission = TRUE
 
-/obj/item/gun/energy/laser/awaymission_aeg/process()
+/obj/item/gun/energy/laser/awaymission_aeg/Initialize(mapload)
+	RegisterSignal(src, list(COMSIG_MOVABLE_Z_CHANGED), .proc/updateZ)
+	// Force update it incase it spawns outside an away mission and shouldnt be charged
+	updateZ()
+	return ..()
+
+/obj/item/gun/energy/laser/awaymission_aeg/proc/updateZ()
 	var/turf/my_loc = get_turf(src)
 	if(is_away_level(my_loc.z))
-		if(inawaymission)
-			return ..()
 		if(ismob(loc))
 			to_chat(loc, "<span class='notice'>Your [src] activates, starting to draw power from a nearby wireless power source.</span>")
-		inawaymission = 1
+		inawaymission = TRUE
 	else
 		if(inawaymission)
 			if(ismob(loc))
 				to_chat(loc, "<span class='danger'>Your [src] deactivates, as it is out of range from its power source.</span>")
 			cell.charge = 0
-			inawaymission = 0
+			inawaymission = FALSE
 			update_icon()
-
-
 
 /obj/item/reagent_containers/glass/beaker/terror_black_toxin
 	name = "beaker 'Black Terror Venom'"

--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -191,31 +191,25 @@
 	origin_tech = null
 	selfcharge = 1
 	can_charge = 0
-	var/inawaymission = TRUE
+	// Selfcharge is enabled and disabled, and used as the away mission tracker
+	selfcharge = TRUE
 
 /obj/item/gun/energy/laser/awaymission_aeg/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, list(COMSIG_MOVABLE_Z_CHANGED), .proc/updateZ)
 	// Force update it incase it spawns outside an away mission and shouldnt be charged
-	updateZ()
+	onTransitZ(new_z=loc.z)
 
-/obj/item/gun/energy/laser/awaymission_aeg/process()
-	// Only call the self-recharge proc if inside an away mission
-	if(inawaymission)
-		..()
-
-/obj/item/gun/energy/laser/awaymission_aeg/proc/updateZ()
-	var/turf/my_loc = get_turf(src)
-	if(is_away_level(my_loc.z))
+/obj/item/gun/energy/laser/awaymission_aeg/onTransitZ(old_z, new_z)
+	if(is_away_level(new_z))
 		if(ismob(loc))
 			to_chat(loc, "<span class='notice'>Your [src] activates, starting to draw power from a nearby wireless power source.</span>")
-		inawaymission = TRUE
+		selfcharge = TRUE
 	else
-		if(inawaymission)
+		if(selfcharge)
 			if(ismob(loc))
 				to_chat(loc, "<span class='danger'>Your [src] deactivates, as it is out of range from its power source.</span>")
 			cell.charge = 0
-			inawaymission = FALSE
+			selfcharge = FALSE
 			update_icon()
 
 /obj/item/reagent_containers/glass/beaker/terror_black_toxin

--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -194,10 +194,10 @@
 	var/inawaymission = TRUE
 
 /obj/item/gun/energy/laser/awaymission_aeg/Initialize(mapload)
+	. = ..()
 	RegisterSignal(src, list(COMSIG_MOVABLE_Z_CHANGED), .proc/updateZ)
 	// Force update it incase it spawns outside an away mission and shouldnt be charged
 	updateZ()
-	return ..()
 
 /obj/item/gun/energy/laser/awaymission_aeg/proc/updateZ()
 	var/turf/my_loc = get_turf(src)

--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -197,7 +197,7 @@
 /obj/item/gun/energy/laser/awaymission_aeg/Initialize(mapload)
 	. = ..()
 	// Force update it incase it spawns outside an away mission and shouldnt be charged
-	onTransitZ(new_z=loc.z)
+	onTransitZ(new_z = loc.z)
 
 /obj/item/gun/energy/laser/awaymission_aeg/onTransitZ(old_z, new_z)
 	if(is_away_level(new_z))

--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -199,6 +199,11 @@
 	// Force update it incase it spawns outside an away mission and shouldnt be charged
 	updateZ()
 
+/obj/item/gun/energy/laser/awaymission_aeg/process()
+	// Only call the self-recharge proc if inside an away mission
+	if(inawaymission)
+		..()
+
 /obj/item/gun/energy/laser/awaymission_aeg/proc/updateZ()
 	var/turf/my_loc = get_turf(src)
 	if(is_away_level(my_loc.z))

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -602,7 +602,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return 0
 	if(usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf)))
-		if(!allowed(usr) && !emagged && locked != -1 && href_list["vend"])
+		if(!allowed(usr) && !emagged && locked != -1 && scan_id && href_list["vend"])
 			to_chat(usr, "<span class='warning'>Access denied.</span>")
 			SSnanoui.update_uis(src)
 			return 0

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -42,7 +42,7 @@
 		H.set_sight(new /datum/vision_override/nightvision)
 		to_chat(H, "<span class='notice'>You adjust your vision to pierce the darkness.</span>")
 	else
-		H.set_sight()
+		H.set_sight(null)
 		to_chat(H, "<span class='notice'>You adjust your vision to recognize the shadows.</span>")
 
 /datum/species/shadow/on_species_gain(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -39,10 +39,10 @@
 /datum/action/innate/shadow/darkvision/Activate()
 	var/mob/living/carbon/human/H = owner
 	if(!H.vision_type)
-		H.vision_type = new /datum/vision_override/nightvision
+		H.set_sight(new /datum/vision_override/nightvision)
 		to_chat(H, "<span class='notice'>You adjust your vision to pierce the darkness.</span>")
 	else
-		H.vision_type = null
+		H.set_sight()
 		to_chat(H, "<span class='notice'>You adjust your vision to recognize the shadows.</span>")
 
 /datum/species/shadow/on_species_gain(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -39,7 +39,7 @@
 /datum/action/innate/shadow/darkvision/Activate()
 	var/mob/living/carbon/human/H = owner
 	if(!H.vision_type)
-		H.set_sight(new /datum/vision_override/nightvision)
+		H.set_sight(/datum/vision_override/nightvision)
 		to_chat(H, "<span class='notice'>You adjust your vision to pierce the darkness.</span>")
 	else
 		H.set_sight(null)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1356,6 +1356,10 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	SEND_SIGNAL(src, COMSIG_MOB_UPDATE_SIGHT)
 	sync_lighting_plane_alpha()
 
+/mob/proc/set_sight(datum/vision_override/O)
+	vision_type = O
+	update_sight()
+
 /mob/proc/sync_lighting_plane_alpha()
 	if(hud_used)
 		var/obj/screen/plane_master/lighting/L = hud_used.plane_masters["[LIGHTING_PLANE]"]

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1357,9 +1357,9 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	sync_lighting_plane_alpha()
 
 /mob/proc/set_sight(datum/vision_override/O)
-	if(vision_type)
-		qdel(vision_type) //qdel the old vision_type unless it is null.
-	vision_type = O
+	QDEL_NULL(vision_type)
+	if(O) //in case of null
+		vision_type = new O
 	update_sight()
 
 /mob/proc/sync_lighting_plane_alpha()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1357,6 +1357,8 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	sync_lighting_plane_alpha()
 
 /mob/proc/set_sight(datum/vision_override/O)
+	if(vision_type)
+		qdel(vision_type) //qdel the old vision_type unless it is null.
 	vision_type = O
 	update_sight()
 

--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -18,18 +18,18 @@
 /datum/reagent/consumable/ethanol/reaction_obj(obj/O, volume)
 	if(istype(O,/obj/item/paper))
 		if(istype(O,/obj/item/paper/contract/infernal))
-			to_chat(usr, "The solution ignites on contact with the [O].")
+			O.visible_message("<span class='warning'>The solution ignites on contact with [O].</span>")
 		else
 			var/obj/item/paper/paperaffected = O
 			paperaffected.clearpaper()
-			to_chat(usr, "The solution melts away the ink on the paper.")
+			paperaffected.visible_message("<span class='notice'>The solution melts away the ink on the paper.</span>")
 	if(istype(O,/obj/item/book))
 		if(volume >= 5)
 			var/obj/item/book/affectedbook = O
 			affectedbook.dat = null
-			to_chat(usr, "The solution melts away the ink on the book.")
+			affectedbook.visible_message("<span class='notice'>The solution melts away the ink on the book.</span>")
 		else
-			to_chat(usr, "It wasn't enough...")
+			O.visible_message("<span class='warning'>It wasn't enough...</span>")
 
 /datum/reagent/consumable/ethanol/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume)//Splashing people with ethanol isn't quite as good as fuel.
 	if(method == REAGENT_TOUCH)
@@ -1190,12 +1190,12 @@
 	taste_description = "motor oil"
 
 /datum/reagent/consumable/ethanol/synthanol/on_mob_life(mob/living/M)
+	metabolization_rate = REAGENTS_METABOLISM
 	if(!(M.dna.species.reagent_tag & PROCESS_SYN))
-		holder.remove_reagent(id, 3.6) //gets removed from organics very fast
+		metabolization_rate += 3.6 //gets removed from organics very fast
 		if(prob(25))
-			holder.remove_reagent(id, 15)
+			metabolization_rate += 15
 			M.fakevomit()
-
 	return ..()
 
 /datum/reagent/consumable/ethanol/synthanol/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume)

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -416,6 +416,7 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor
 	suit_store = /obj/item/gun/energy/gun
 	r_pocket = /obj/item/nullrod/ert
+	l_pocket = /obj/item/paranormal_scanner
 	glasses = /obj/item/clothing/glasses/sunglasses
 
 	cybernetic_implants = list(
@@ -429,8 +430,9 @@
 	suit_store = /obj/item/gun/energy/gun/nuclear
 	l_pocket = /obj/item/grenade/clusterbuster/holy
 	shoes = /obj/item/clothing/shoes/magboots/advance
-	glasses = /obj/item/clothing/glasses/night
 	r_pocket = /obj/item/nullrod/ert
+	l_pocket = /obj/item/paranormal_scanner/advanced
+	glasses = /obj/item/clothing/glasses/night
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -327,7 +327,7 @@
 	user.visible_message("[user] shines light onto the tumor in [target]'s [E]!", "<span class='notice'>You cleanse the contamination from [target]'s brain!</span>")
 	if(target.vision_type) //Turns off their darksight if it's still active.
 		to_chat(target, "<span class='boldannounce'>Your eyes are suddenly wrought with immense pain as your darksight is forcibly dismissed!</span>")
-		target.vision_type = null
+		target.set_sight(null)
 	SSticker.mode.remove_thrall(target.mind, 0)
 	target.visible_message("<span class='warning'>A strange black mass falls from [target]'s [E]!</span>")
 	var/obj/item/organ/thing = new /obj/item/organ/internal/shadowtumor(get_turf(target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Based on https://github.com/ParadiseSS13/Paradise/pull/12151

This PR adds the paranormal scanner to Red Inquisitors and the advanced paranormal scanner to Gamma Inquisitors.

The paranormal scanner when used on a human will scan them. After 20 (10 for advanced) seconds, it will reveal if the target is a Vampire, Vampire Thrall, Cultist, Devil, or Wizard.

The main purpose and use case of the scanner is as an admin response to an effective mindswap wizard, which currently has no existing counters as there is no possible test for wizards (other than knowing who was swapped or seeing the wiz cast shit, which removes the need for a test).

As it is slow to use and requires both you and the target to be immobile, it is probably still better to use holy water to test for vamps and cultists, which is intentional. This can still be used to test non-mindshielded command and make sure they are trustworthy, for example.

Currently the scanner uses the spectrometer/advanced spectrometer sprites. I will look into getting unique sprites for it if feedback is positive.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Added the paranormal scanner to Red and Gamma Inquisitor ERT.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
