### PR TITLE
Add the command crew monitor

### DIFF
--- a/code/_globalvars/lists/misc.dm
+++ b/code/_globalvars/lists/misc.dm
@@ -58,4 +58,10 @@ GLOBAL_LIST_INIT(cooking_reagents, list(RECIPE_MICROWAVE = list(), RECIPE_OVEN =
 
 GLOBAL_LIST(station_level_space_turfs)
 
+GLOBAL_LIST_INIT(command_and_vips, list("Captain", "Acting Captain", "Head of Personnel", "Head of Security", "Chief Medical Officer", "Chief Engineer",
+						"Research Director", "Magistrate", "Nanotrasen Representative", "Blueshield", "Nanotrasen Navy Officer", "Special Operations Officer",
+						"Nanotrasen Navy Captain", "Nanotrasen Diplomat", "Emergency Response Team Leader", "Emergency Response Team Officer",
+						"Emergency Response Team Engineer","Emergency Response Team Medic", "Emergency Response Team Inquisitor",
+						"Emergency Response Team Janitor", "HONKsquad"))
+
 #define EGG_LAYING_MESSAGES list("lays an egg.", "squats down and croons.", "begins making a huge racket.", "begins clucking raucously.")

--- a/code/datums/cache/crew.dm
+++ b/code/datums/cache/crew.dm
@@ -1,4 +1,5 @@
 var/global/datum/repository/crew/crew_repository = new()
+var/global/datum/repository/crew/command/command_repository = new()
 
 /datum/repository/crew/New()
 	cache_data = list()
@@ -63,5 +64,14 @@ var/global/datum/repository/crew/crew_repository = new()
 		if(istype(H.w_uniform, /obj/item/clothing/under))
 			var/obj/item/clothing/under/C = H.w_uniform
 			if(C.has_sensor)
+				tracked |= C
+	return tracked
+
+/datum/repository/crew/command/scan()
+	var/list/tracked = list()
+	for(var/mob/living/carbon/human/H in GLOB.mob_list)
+		if(istype(H.w_uniform, /obj/item/clothing/under))
+			var/obj/item/clothing/under/C = H.w_uniform
+			if(C.has_sensor && (H.get_assignment() in GLOB.command_and_vips))
 				tracked |= C
 	return tracked

--- a/code/game/objects/items/devices/sensor_device.dm
+++ b/code/game/objects/items/devices/sensor_device.dm
@@ -20,3 +20,11 @@
 
 /obj/item/sensor_device/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	crew_monitor.ui_interact(user, ui_key, ui, force_open)
+
+/obj/item/sensor_device/command
+	name = "command crew monitor"
+	desc = "A handheld crew monitor programmed to only track Command personnel and Nanotrasen VIPs, usually carried by Blueshields."
+
+/obj/item/sensor_device/command/New()
+	..()
+	crew_monitor.command = TRUE

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -244,6 +244,7 @@
 	new /obj/item/storage/briefcase(src)
 	new	/obj/item/storage/firstaid/adv(src)
 	new /obj/item/pinpointer/crew(src)
+	new /obj/item/sensor_device/command(src)
 	new /obj/item/storage/belt/security/sec(src)
 	new /obj/item/grenade/flashbang(src)
 	new /obj/item/flash(src)

--- a/code/modules/nano/modules/crew_monitor.dm
+++ b/code/modules/nano/modules/crew_monitor.dm
@@ -1,5 +1,6 @@
 /datum/nano_module/crew_monitor
 	name = "Crew monitor"
+	var/command = FALSE
 
 /datum/nano_module/crew_monitor/Topic(href, href_list)
 	if(..())
@@ -36,6 +37,9 @@
 	var/turf/T = get_turf(nano_host())
 
 	data["isAI"] = isAI(user)
-	data["crewmembers"] = crew_repository.health_data(T)
+	if(command)
+		data["crewmembers"] = command_repository.health_data(T)
+	else
+		data["crewmembers"] = crew_repository.health_data(T)
 
 	return data

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -92,6 +92,12 @@
 	build_path = /obj/item/sensor_device
 	category = list("Medical")
 
+/datum/design/sensor_device/command
+	name = "Command Crew Monitor"
+	desc = "A handheld crew monitor programmed to only track Command personnel and Nanotrasen VIPs."
+	id = "sensor_device_command"
+	build_path = /obj/item/sensor_device/command
+
 /datum/design/mmi
 	name = "Man-Machine Interface"
 	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity."

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -64,7 +64,8 @@
 		/obj/item/clothing/mask/gas/sechailer = 1,
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/storage/lockbox/mindshield = 1,
-		/obj/item/flashlight = 1
+		/obj/item/flashlight = 1,
+		/obj/item/sensor_device/command = 1
 	)
 
 /datum/outfit/job/centcom/response_team/commander/red
@@ -84,7 +85,8 @@
 		/obj/item/gun/energy/ionrifle/carbine = 1,
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/clothing/shoes/magboots = 1,
-		/obj/item/storage/lockbox/mindshield = 1
+		/obj/item/storage/lockbox/mindshield = 1,
+		/obj/item/sensor_device/command = 1
 	)
 
 /datum/outfit/job/centcom/response_team/commander/gamma
@@ -101,7 +103,8 @@
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/storage/lockbox/mindshield = 1,
 		/obj/item/gun/energy/ionrifle/carbine = 1,
-		/obj/item/ammo_box/magazine/enforcer/lethal = 2
+		/obj/item/ammo_box/magazine/enforcer/lethal = 2,
+		/obj/item/sensor_device/command = 1
 		)
 
 	cybernetic_implants = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Based on https://github.com/ParadiseSS13/Paradise/pull/12150

This PR adds the command crew monitor to the Blueshield's locker, the Emergency Response Team Leader's backpack (all levels), and the Protolathe's medical designs (same cost and requirements as the standard crew monitor).

The command crew monitor functions just like the standard crew monitor, however it filters out anyone who isnt a Command member, a NT VIP, or an ERT/CC official.

Somebody with the custom title 'Acting Captain' will show up on the command monitor as they should be a member of Command proper, unlike other acting command staff.

Deathsquad and undercover NT agents are not shown for obvious reasons.

In the hands of the Blueshield, this will help focus them on their mission of protecting their charges without distraction from people that should be helped by medical and/or sec.

In the hands of the ERT leader, it lets them monitor the status of their team, and locate the members of Command they should be coordinating with.

Replacements can be printed at the protolathe if lost.

Using this instead of a standard crew monitor does have a downside : The filter is ID based. If a command member is stripped of their ID or if they alter their title to a custom job that isnt 'Acting Captain', they wont show up.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Added the command crew monitor to Blueshield's locker and ERT Leader's backpack, which only shows the sensors of Command, NT VIPs, ERTs, and CC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
